### PR TITLE
Use default Laravel migration structure

### DIFF
--- a/database/migrations/create_laravel_log_table.php.stub
+++ b/database/migrations/create_laravel_log_table.php.stub
@@ -6,6 +6,9 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * Run the migrations.
+     */
     public function up(): void
     {
         Schema::create('log_messages', function (Blueprint $table) {
@@ -17,5 +20,13 @@ return new class extends Migration
             $table->json('context');
             $table->json('extra');
         });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('log_messages');
     }
 };


### PR DESCRIPTION
This PR adds the `down()` method to the migration and adds the default Laravel docblocks.