### PR TITLE
Adds to the configuration the minimum log level to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ return [
             'via'        => DatabaseLogger::class,
             'connection' => env('LOG_DB_CONNECTION'), // Optional, defaults to app's DB connection
             'days'       => 7, // Optional, retention period in days
+            'level'      => env('LOG_LEVEL', 'debug'),
         ],
     ]   
 ]

--- a/src/DatabaseHandler.php
+++ b/src/DatabaseHandler.php
@@ -18,8 +18,8 @@ class DatabaseHandler extends AbstractProcessingHandler
     {
         $record = is_array($record) ? $record : $record->toArray();
 
-        if ($minimumLevel = config('logging.channels.db.level')) {
-            if ($record['level'] < Logger::toMonologLevel($minimumLevel)->value) return;
+        if ($this->hasMinimumLevelSet() && ! $this->meetsLevelThreshold($record['level'])) {
+            return;
         }
 
         $exception = $record['context']['exception'] ?? null;
@@ -46,5 +46,21 @@ class DatabaseHandler extends AbstractProcessingHandler
                 'exception' => $e,
             ]);
         }
+    }
+
+    public function hasMinimumLevelSet()
+    {
+        return config('logging.channels.db.level') !== null;
+    }
+
+    public function meetsLevelThreshold(int $currentLevel): bool
+    {
+        $minimumLevel = Logger::toMonologLevel(config('logging.channels.db.level'));
+
+        if (! is_int($minimumLevel)) {
+            $minimumLevel = $minimumLevel->value;
+        }
+
+        return $currentLevel >= $minimumLevel;
     }
 }

--- a/src/DatabaseHandler.php
+++ b/src/DatabaseHandler.php
@@ -18,8 +18,8 @@ class DatabaseHandler extends AbstractProcessingHandler
     {
         $record = is_array($record) ? $record : $record->toArray();
 
-        if ($currentLevel = config('logging.channels.db.level')) {
-            if ($record['level'] < Logger::toMonologLevel($currentLevel)->value) return;
+        if ($minimumLevel = config('logging.channels.db.level')) {
+            if ($record['level'] < Logger::toMonologLevel($minimumLevel)->value) return;
         }
 
         $exception = $record['context']['exception'] ?? null;

--- a/src/DatabaseHandler.php
+++ b/src/DatabaseHandler.php
@@ -5,6 +5,7 @@ namespace Yoeriboven\LaravelLogDb;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
 use Throwable;
 use Yoeriboven\LaravelLogDb\Models\LogMessage;
 
@@ -16,6 +17,10 @@ class DatabaseHandler extends AbstractProcessingHandler
     protected function write($record): void
     {
         $record = is_array($record) ? $record : $record->toArray();
+
+        if ($currentLevel = config('logging.channels.db.level')) {
+            if ($record['level'] < Logger::toMonologLevel($currentLevel)->value) return;
+        }
 
         $exception = $record['context']['exception'] ?? null;
 

--- a/tests/DatabaseLoggingTest.php
+++ b/tests/DatabaseLoggingTest.php
@@ -43,7 +43,7 @@ it('correctly logs exceptions', function () {
     );
 });
 
-it('stores messages over the configured level', function () {
+it('stores messages more severe than the minimum level', function () {
     config()->set('logging.channels.db.level', 'error');
 
     Log::channel('db')->debug('Invisible messages');

--- a/tests/DatabaseLoggingTest.php
+++ b/tests/DatabaseLoggingTest.php
@@ -43,6 +43,26 @@ it('correctly logs exceptions', function () {
     );
 });
 
+it('stores messages over the configured level', function () {
+    config()->set('logging.channels.db.level', 'error');
+
+    Log::channel('db')->debug('Invisible messages');
+    Log::channel('db')->info('Invisible messages');
+    Log::channel('db')->notice('Invisible messages');
+    Log::channel('db')->warning('Invisible messages');
+
+    $this->assertDatabaseMissing('log_messages', [
+        'message' => 'Invisible messages',
+    ]);
+
+    Log::channel('db')->error('Test message');
+
+    $this->assertDatabaseHas('log_messages', [
+        'level_name' => mb_strtoupper('error'),
+        'message' => 'Test message',
+    ]);
+});
+
 it('uses the default connection if no custom connection is set', function () {
     $model = new LogMessage();
 


### PR DESCRIPTION
Checking the value of `config('logging.channels.db.level')` against the current log level before writing to database